### PR TITLE
Extend/File代码逻辑错误,缓存失效，谢谢@李东提出的issues

### DIFF
--- a/src/WeChat/Extend/File.php
+++ b/src/WeChat/Extend/File.php
@@ -33,10 +33,10 @@ class File
             $fileCont[$var] = $val;
             file_put_contents($file_path,json_encode($fileCont));
         }
-        if(!empty($val) and empty($var)){
+        if(empty($val) and !empty($var)){
             if ($fileCont[$var]['time'] - time() <= 7100){
                 unset($fileCont[$var]['time']);
-                if (!empty($fileCont[$var])) return $fileCont[$var];
+                if (isset($fileCont[$var])) return $fileCont[$var];
             }
             return null;
         }


### PR DESCRIPTION
wechat/src/WeChat/Extend/File.php中约36行处

if(!empty($val) and empty($var)){
            if ($fileCont[$var]['time'] - time() <= 7100){
应该改为

if(empty($val) and !empty($var)){